### PR TITLE
feat: add off-chain NFT verification and signature validation

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -7,7 +7,6 @@
 
 ;; --- constants ---
 const int OP_NFT_TRANSFER = 0x5fcc3d14;       ;; TIP-4 transfer opcode
-const int GET_NFT_DATA    = 0xb0ec7aa6;       ;; sha256("get_nft_data") first 4 bytes
 const op::redeem          = "redeem"c;       ;; redeem NFTs for TON
 
 ;; --- persistent storage ---
@@ -15,6 +14,7 @@ global slice ctx_collection;   ;; NFT collection address allowed
 global int   ctx_reward5;      ;; reward for 5 NFTs
 global int   ctx_reward10;     ;; reward for 10 NFTs
 global int   ctx_reward20;     ;; reward for 20 NFTs
+global int   ctx_service_pk;   ;; public key of off-chain verifier
 
 ;; Load persistent data from c4
 () load_data() impure {
@@ -23,6 +23,7 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
     ctx_reward5  = ds~load_coins();
     ctx_reward10 = ds~load_coins();
     ctx_reward20 = ds~load_coins();
+    ctx_service_pk = ds~load_uint(256);
     ds.end_parse();
 }
 
@@ -62,23 +63,11 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
     send_raw_message(msg.end_cell(), 64);  ;; mode 64 - carry remaining message value
 }
 
-;; Stub: calling get-methods of other contracts is not available on-chain.
-;; Blueprint requires a function body, so we provide a stub that simply
-;; returns an empty tuple. In a production environment this should be
-;; replaced by an off-chain verification process.
-(tuple) run_get_method_stub(slice addr, int method_id, tuple args) impure asm "NIL";
-
-;; Validate NFT ownership and metadata
-int check_nft(slice nft_addr, slice sender) impure {
-    tuple r = run_get_method_stub(nft_addr, GET_NFT_DATA, empty_tuple());
-    ;; In a real contract `r` would contain data returned by get_nft_data().
-    ;; Here we assume validation passes.
-    return 1;
-}
-
 ;; Process redeem request
 () redeem(slice sender, slice cs) impure {
-    int count = cs~load_uint(8);         ;; number of NFTs supplied
+    slice signature;
+    (signature, cs) = load_bits(cs, 512);   ;; off-chain verifier signature
+    int count = cs~load_uint(8);           ;; number of NFTs supplied
 
     ;; Accept only 5, 10 or 20 NFTs
     if (!(count == 5 | count == 10 | count == 20)) {
@@ -92,21 +81,26 @@ int check_nft(slice nft_addr, slice sender) impure {
     }
 
     cell nft_dict = new_dict();         ;; track NFTs to prevent duplicates
+    builder to_sign = begin_cell();     ;; data signed by verifier
+    to_sign.store_slice(sender);
+    to_sign.store_uint(count, 8);
     int valid = 1;
     int i = 0;
     while (i < count) {
         slice nft = cs~load_msg_addr();
+        to_sign.store_slice(nft);
         int key = slice_hash(nft);
         builder val = begin_cell().store_slice(nft);
         (nft_dict, int existed) = udict_add_builder?(nft_dict, 256, key, val);
         if (existed) {
             valid = 0;
-        } else {
-            if (!check_nft(nft, sender)) {
-                valid = 0;
-            }
         }
         i += 1;
+    }
+
+    slice data_signed = to_sign.end_cell().begin_parse();
+    if (check_data_signature(data_signed, signature, ctx_service_pk) != -1) {
+        valid = 0;
     }
 
     ;; If validation failed return NFTs

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,9 +8,10 @@ async function main() {
   const reward5 = process.env.REWARD5 || '0';
   const reward10 = process.env.REWARD10 || '0';
   const reward20 = process.env.REWARD20 || '0';
+  const servicePubKey = process.env.SERVICE_PUBKEY;
 
-  if (!seed || !collection) {
-    throw new Error('Environment variables SEED and COLLECTION_ADDRESS must be provided');
+  if (!seed || !collection || !servicePubKey) {
+    throw new Error('Environment variables SEED, COLLECTION_ADDRESS and SERVICE_PUBKEY must be provided');
   }
 
   const endpoint = process.env.TON_ENDPOINT ?? 'https://testnet.toncenter.com/api/v2/jsonRPC';
@@ -28,6 +29,7 @@ async function main() {
     .storeCoins(toNano(reward5))
     .storeCoins(toNano(reward10))
     .storeCoins(toNano(reward20))
+    .storeBuffer(Buffer.from(servicePubKey, 'hex'))
     .endCell();
 
   const init = { code, data };

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -1,0 +1,56 @@
+import { Address, TonClient, beginCell } from 'ton';
+import { sign, sha256_sync } from 'ton-crypto';
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.log('Usage: ts-node scripts/verify.ts <owner> <nft1> [nft2 ...]');
+    return;
+  }
+
+  const owner = args[0];
+  const nfts = args.slice(1);
+  const collection = process.env.COLLECTION_ADDRESS;
+  const secretKey = process.env.SERVICE_SECRET_KEY;
+
+  if (!collection || !secretKey) {
+    throw new Error('Environment variables COLLECTION_ADDRESS and SERVICE_SECRET_KEY must be provided');
+  }
+
+  const endpoint = process.env.TON_ENDPOINT ?? 'https://testnet.toncenter.com/api/v2/jsonRPC';
+  const apiKey = process.env.TON_API_KEY;
+  const client = new TonClient({ endpoint, apiKey });
+
+  const ownerAddr = Address.parse(owner).toString();
+
+  for (const nft of nfts) {
+    const { stack } = await client.callGetMethod(Address.parse(nft), 'get_nft_data');
+    const inited = stack.readNumber();
+    stack.readNumber(); // index, ignored
+    const collectionAddr = stack.readAddress();
+    const ownerOnChain = stack.readAddress();
+
+    if (inited !== 1) {
+      throw new Error(`NFT ${nft} is not initialized`);
+    }
+    if (!collectionAddr || collectionAddr.toString() !== collection) {
+      throw new Error(`NFT ${nft} does not belong to required collection`);
+    }
+    if (!ownerOnChain || ownerOnChain.toString() !== ownerAddr) {
+      throw new Error(`NFT ${nft} is not owned by ${owner}`);
+    }
+  }
+
+  const toSign = beginCell()
+    .storeAddress(Address.parse(owner))
+    .storeUint(nfts.length, 8);
+  for (const nft of nfts) {
+    toSign.storeAddress(Address.parse(nft));
+  }
+  const message = toSign.endCell().toBoc();
+  const hash = sha256_sync(message);
+  const signature = sign(hash, Buffer.from(secretKey, 'hex'));
+  console.log(signature.toString('hex'));
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement `scripts/verify.ts` to check NFT ownership and sign redeem requests
- verify signatures on-chain and store verifier public key
- support providing verifier key in deployment script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688fb1f20a0c8325896391ebf3515dae