### PR TITLE
Add Jet client for contract deployment and redeem

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ Environment variables:
 - `contracts/jet.fc` – FunC contract skeleton
 - `package.json` – npm scripts and dependencies
 
+## Client Library
+
+The `JetClient` module exposes helper functions for interacting with the contract.
+It uses [`ton-core`](https://github.com/ton-community/ton-core) for message
+serialization and is exported as the package's main entry.
+
+```ts
+import { JetClient, deploy, redeem, readState } from 'Jet';
+```
+
+- `deploy(client, wallet, secretKey, config, code)` – deploy the contract.
+- `redeem(client, wallet, secretKey, jet, signature, nfts)` – redeem a list of
+  NFT addresses for the configured reward.
+- `readState(client, address)` – fetch on-chain configuration of the contract.
+
 ## License
 
 MIT

--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -1,0 +1,143 @@
+import { Address, Cell, beginCell, contractAddress, toNano, Contract, ContractProvider, Sender } from 'ton-core';
+import { TonClient, WalletContractV4, internal } from 'ton';
+
+export const OP_REDEEM = 0x72656465; // "redeem" prefix
+
+export type JetConfig = {
+  collection: Address;
+  reward5: bigint;
+  reward10: bigint;
+  reward20: bigint;
+  servicePubKey: Buffer;
+};
+
+export function jetConfigToCell(config: JetConfig): Cell {
+  return beginCell()
+    .storeAddress(config.collection)
+    .storeCoins(config.reward5)
+    .storeCoins(config.reward10)
+    .storeCoins(config.reward20)
+    .storeBuffer(config.servicePubKey)
+    .endCell();
+}
+
+export class JetClient implements Contract {
+  readonly address: Address;
+  readonly init?: { code: Cell; data: Cell };
+
+  constructor(address: Address, init?: { code: Cell; data: Cell }) {
+    this.address = address;
+    this.init = init;
+  }
+
+  static createFromConfig(config: JetConfig, code: Cell, workchain = 0) {
+    const data = jetConfigToCell(config);
+    const init = { code, data };
+    const address = contractAddress(workchain, init);
+    return new JetClient(address, init);
+  }
+
+  async sendDeploy(provider: ContractProvider, via: Sender, value: bigint = toNano('0.05')) {
+    if (!this.init) throw new Error('Init required for deploy');
+    await provider.internal(via, {
+      value,
+      bounce: false,
+      init: this.init,
+    });
+  }
+
+  async sendRedeem(provider: ContractProvider, via: Sender, opts: { signature: Buffer; nfts: Address[]; value?: bigint }) {
+    const value = opts.value ?? toNano('0.05');
+    const body = beginCell()
+      .storeUint(OP_REDEEM, 32)
+      .storeBuffer(opts.signature)
+      .storeUint(opts.nfts.length, 8);
+    for (const nft of opts.nfts) {
+      body.storeAddress(nft);
+    }
+    await provider.internal(via, {
+      value,
+      body: body.endCell(),
+    });
+  }
+
+  async getState(provider: ContractProvider): Promise<JetConfig> {
+    const state = await provider.getState();
+    if (!state.data) throw new Error('No state data');
+    const cs = state.data.beginParse();
+    return {
+      collection: cs.loadAddress(),
+      reward5: cs.loadCoins(),
+      reward10: cs.loadCoins(),
+      reward20: cs.loadCoins(),
+      servicePubKey: cs.loadBuffer(32),
+    };
+  }
+}
+
+export async function deploy(
+  client: TonClient,
+  wallet: WalletContractV4,
+  secretKey: Buffer,
+  config: JetConfig,
+  code: Cell,
+  value: bigint = toNano('0.05'),
+): Promise<JetClient> {
+  const jet = JetClient.createFromConfig(config, code);
+  const walletContract = client.open(wallet);
+  const seqno = await walletContract.getSeqno();
+  await walletContract.sendTransfer({
+    secretKey,
+    seqno,
+    messages: [
+      internal({
+        to: jet.address,
+        value,
+        bounce: false,
+        init: jet.init,
+      }),
+    ],
+  });
+  return jet;
+}
+
+export async function redeem(
+  client: TonClient,
+  wallet: WalletContractV4,
+  secretKey: Buffer,
+  jet: JetClient,
+  signature: Buffer,
+  nfts: Address[],
+  value: bigint = toNano('0.05'),
+): Promise<void> {
+  const walletContract = client.open(wallet);
+  const seqno = await walletContract.getSeqno();
+  const body = beginCell()
+    .storeUint(OP_REDEEM, 32)
+    .storeBuffer(signature)
+    .storeUint(nfts.length, 8);
+  for (const nft of nfts) {
+    body.storeAddress(nft);
+  }
+  await walletContract.sendTransfer({
+    secretKey,
+    seqno,
+    messages: [
+      internal({ to: jet.address, value, body: body.endCell() }),
+    ],
+  });
+}
+
+export async function readState(client: TonClient, address: Address): Promise<JetConfig> {
+  const state = await client.getContractState(address);
+  if (!state.data) throw new Error('No state found');
+  const data = Cell.fromBoc(state.data)[0];
+  const cs = data.beginParse();
+  return {
+    collection: cs.loadAddress(),
+    reward5: cs.loadCoins(),
+    reward10: cs.loadCoins(),
+    reward20: cs.loadCoins(),
+    servicePubKey: cs.loadBuffer(32),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "Jet",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "ton": "^13.9.0",
+        "ton-core": "^0.53.0"
+      },
       "devDependencies": {
         "@ton-community/blueprint": "^0.12.0"
       }
@@ -480,9 +484,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
       "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.7"
       }
@@ -546,13 +548,6 @@
         "it-take": "^1.0.1",
         "multiformats": "^9.4.7"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-      "extraneous": true,
-      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "6.0.3",
@@ -776,7 +771,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
       "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1009,7 +1003,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1474,7 +1467,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.2.0.tgz",
       "integrity": "sha512-QuruyBENDWdN4tZwJbQq7/eAK85FqrI4oDbXjy5IBhYD+2pTJyBUWZe8ctWaCkrV0gy6AaelgOZZBMeswEa/6Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -2092,14 +2084,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol.inspect/-/symbol.inspect-1.0.1.tgz",
       "integrity": "sha512-YQSL4duoHmLhsTD1Pw8RW6TZ5MaTX5rXJnqacJottr2P2LZBF/Yvrc3ku4NUpMOm8aM0KOCqM+UAkMA5HWQCzQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/teslabot": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/teslabot/-/teslabot-1.5.0.tgz",
       "integrity": "sha512-e2MmELhCgrgZEGo7PQu/6bmYG36IDH+YrBI1iGm6jovXkeDIGa3pZ2WSqRjzkuw2vt1EqfkZoV5GpXgqL8QJVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through": {
@@ -2126,9 +2116,7 @@
       "version": "13.9.0",
       "resolved": "https://registry.npmjs.org/ton/-/ton-13.9.0.tgz",
       "integrity": "sha512-IjZa4vFsyYHzQFY3kMSK/vw8T9b4zSJlSkZOgD8qeP4AFVxcD6pZ7TxfATwLJnA/4MCbaM9DY0V076oMjluDQg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "axios": "^0.25.0",
         "dataloader": "^2.0.0",
@@ -2145,9 +2133,7 @@
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/ton-core/-/ton-core-0.53.0.tgz",
       "integrity": "sha512-uO/U1oVLdEliWWbwfNQQK+61C+KM0ehcTdHQ6cN0WSEH2UzGfdVFpC4Wb0ph+wUYe/5njl7TA0uL9nif9Q6qwA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "symbol.inspect": "1.0.1"
       },
@@ -2159,7 +2145,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ton-crypto/-/ton-crypto-3.2.0.tgz",
       "integrity": "sha512-fltdBNQ45gARMuGMEOjPZWPJ5eSql8p3CA0Dj7tPv5lhU5ziT8SxXLAzDraR9HJ8YpjBHLVvYyhMLRiEwxgtMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jssha": "3.2.0",
@@ -2171,7 +2156,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ton-crypto-primitives/-/ton-crypto-primitives-2.0.0.tgz",
       "integrity": "sha512-K+qKjpS0h9sPW6oExcpxnzuQ7nEgHEiDKwIqE/jWD25o8iFGe3FWj1gKxFNbKE9wwYKc5IV8FwrU+raF0KO5nQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jssha": "3.2.0"
@@ -2323,7 +2307,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/tweetnacl-util": {
@@ -2476,7 +2459,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,19 @@
   "version": "0.0.1",
   "description": "FunC smart contract skeleton for exchanging non-winning NFTs for TON.",
   "license": "MIT",
+  "main": "client/JetClient.ts",
+  "types": "client/JetClient.ts",
+  "exports": {
+    ".": "./client/JetClient.ts"
+  },
   "scripts": {
     "start": "blueprint run",
     "test": "echo \"No tests\"",
     "deploy": "ts-node scripts/deploy.ts"
+  },
+  "dependencies": {
+    "ton": "^13.9.0",
+    "ton-core": "^0.53.0"
   },
   "devDependencies": {
     "@ton-community/blueprint": "^0.12.0"


### PR DESCRIPTION
## Summary
- add `JetClient` with helpers to deploy, redeem NFTs and read contract state
- expose client as package entry point
- document client API in README

## Testing
- `npm test`