### PR TITLE
Simplify NFT swapper by removing verifier signature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,6 @@ COLLECTION_ADDRESS=""
 REWARD5="0"
 REWARD10="0"
 REWARD20="0"
-# Public key of off-chain verifier
-SERVICE_PUBKEY=""
-# Secret key for verification script
-SERVICE_SECRET_KEY=""
 # Optional TON HTTP API settings
 TON_ENDPOINT="https://testnet.toncenter.com/api/v2/jsonRPC"
 TON_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NFT to TON Swapper
 
-This repository contains a FunC smart contract skeleton that will allow users to swap batches of non-winning Lotshot NFTs for a fixed TON reward.
+This repository contains a FunC smart contract skeleton that allows users to swap batches of Lotshot NFTs for a fixed TON reward.
 
 ## Development
 

--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -8,7 +8,6 @@ export type JetConfig = {
   reward5: bigint;
   reward10: bigint;
   reward20: bigint;
-  servicePubKey: Buffer;
 };
 
 export function jetConfigToCell(config: JetConfig): Cell {
@@ -17,7 +16,6 @@ export function jetConfigToCell(config: JetConfig): Cell {
     .storeCoins(config.reward5)
     .storeCoins(config.reward10)
     .storeCoins(config.reward20)
-    .storeBuffer(config.servicePubKey)
     .endCell();
 }
 
@@ -46,11 +44,10 @@ export class JetClient implements Contract {
     });
   }
 
-  async sendRedeem(provider: ContractProvider, via: Sender, opts: { signature: Buffer; nfts: Address[]; value?: bigint }) {
+  async sendRedeem(provider: ContractProvider, via: Sender, opts: { nfts: Address[]; value?: bigint }) {
     const value = opts.value ?? toNano('0.05');
     const body = beginCell()
       .storeUint(OP_REDEEM, 32)
-      .storeBuffer(opts.signature)
       .storeUint(opts.nfts.length, 8);
     for (const nft of opts.nfts) {
       body.storeAddress(nft);
@@ -70,7 +67,6 @@ export class JetClient implements Contract {
       reward5: cs.loadCoins(),
       reward10: cs.loadCoins(),
       reward20: cs.loadCoins(),
-      servicePubKey: cs.loadBuffer(32),
     };
   }
 }
@@ -106,7 +102,6 @@ export async function redeem(
   wallet: WalletContractV4,
   secretKey: Buffer,
   jet: JetClient,
-  signature: Buffer,
   nfts: Address[],
   value: bigint = toNano('0.05'),
 ): Promise<void> {
@@ -114,7 +109,6 @@ export async function redeem(
   const seqno = await walletContract.getSeqno();
   const body = beginCell()
     .storeUint(OP_REDEEM, 32)
-    .storeBuffer(signature)
     .storeUint(nfts.length, 8);
   for (const nft of nfts) {
     body.storeAddress(nft);
@@ -138,6 +132,5 @@ export async function readState(client: TonClient, address: Address): Promise<Je
     reward5: cs.loadCoins(),
     reward10: cs.loadCoins(),
     reward20: cs.loadCoins(),
-    servicePubKey: cs.loadBuffer(32),
   };
 }

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -14,7 +14,6 @@ global slice ctx_collection;   ;; NFT collection address allowed
 global int   ctx_reward5;      ;; reward for 5 NFTs
 global int   ctx_reward10;     ;; reward for 10 NFTs
 global int   ctx_reward20;     ;; reward for 20 NFTs
-global int   ctx_service_pk;   ;; public key of off-chain verifier
 
 ;; Load persistent data from c4
 () load_data() impure {
@@ -23,7 +22,6 @@ global int   ctx_service_pk;   ;; public key of off-chain verifier
     ctx_reward5  = ds~load_coins();
     ctx_reward10 = ds~load_coins();
     ctx_reward20 = ds~load_coins();
-    ctx_service_pk = ds~load_uint(256);
     ds.end_parse();
 }
 
@@ -65,8 +63,6 @@ global int   ctx_service_pk;   ;; public key of off-chain verifier
 
 ;; Process redeem request
 () redeem(slice sender, slice cs) impure {
-    slice signature;
-    (signature, cs) = load_bits(cs, 512);   ;; off-chain verifier signature
     int count = cs~load_uint(8);           ;; number of NFTs supplied
 
     ;; Accept only 5, 10 or 20 NFTs
@@ -81,14 +77,10 @@ global int   ctx_service_pk;   ;; public key of off-chain verifier
     }
 
     cell nft_dict = new_dict();         ;; track NFTs to prevent duplicates
-    builder to_sign = begin_cell();     ;; data signed by verifier
-    to_sign.store_slice(sender);
-    to_sign.store_uint(count, 8);
     int valid = 1;
     int i = 0;
     while (i < count) {
         slice nft = cs~load_msg_addr();
-        to_sign.store_slice(nft);
         int key = slice_hash(nft);
         builder val = begin_cell().store_slice(nft);
         (nft_dict, int existed) = udict_add_builder?(nft_dict, 256, key, val);
@@ -96,11 +88,6 @@ global int   ctx_service_pk;   ;; public key of off-chain verifier
             valid = 0;
         }
         i += 1;
-    }
-
-    slice data_signed = to_sign.end_cell().begin_parse();
-    if (check_data_signature(data_signed, signature, ctx_service_pk) != -1) {
-        valid = 0;
     }
 
     ;; If validation failed return NFTs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Jet",
   "version": "0.0.1",
-  "description": "FunC smart contract skeleton for exchanging non-winning NFTs for TON.",
+  "description": "FunC smart contract skeleton for exchanging NFTs for TON.",
   "license": "MIT",
   "main": "client/JetClient.ts",
   "types": "client/JetClient.ts",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,10 +8,9 @@ async function main() {
   const reward5 = process.env.REWARD5 || '0';
   const reward10 = process.env.REWARD10 || '0';
   const reward20 = process.env.REWARD20 || '0';
-  const servicePubKey = process.env.SERVICE_PUBKEY;
 
-  if (!seed || !collection || !servicePubKey) {
-    throw new Error('Environment variables SEED, COLLECTION_ADDRESS and SERVICE_PUBKEY must be provided');
+  if (!seed || !collection) {
+    throw new Error('Environment variables SEED and COLLECTION_ADDRESS must be provided');
   }
 
   const endpoint = process.env.TON_ENDPOINT ?? 'https://testnet.toncenter.com/api/v2/jsonRPC';
@@ -29,7 +28,6 @@ async function main() {
     .storeCoins(toNano(reward5))
     .storeCoins(toNano(reward10))
     .storeCoins(toNano(reward20))
-    .storeBuffer(Buffer.from(servicePubKey, 'hex'))
     .endCell();
 
   const init = { code, data };

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -1,5 +1,4 @@
-import { Address, TonClient, beginCell } from 'ton';
-import { sign, sha256_sync } from 'ton-crypto';
+import { Address, TonClient } from 'ton';
 
 async function main() {
   const args = process.argv.slice(2);
@@ -11,10 +10,9 @@ async function main() {
   const owner = args[0];
   const nfts = args.slice(1);
   const collection = process.env.COLLECTION_ADDRESS;
-  const secretKey = process.env.SERVICE_SECRET_KEY;
 
-  if (!collection || !secretKey) {
-    throw new Error('Environment variables COLLECTION_ADDRESS and SERVICE_SECRET_KEY must be provided');
+  if (!collection) {
+    throw new Error('Environment variable COLLECTION_ADDRESS must be provided');
   }
 
   const endpoint = process.env.TON_ENDPOINT ?? 'https://testnet.toncenter.com/api/v2/jsonRPC';
@@ -41,16 +39,7 @@ async function main() {
     }
   }
 
-  const toSign = beginCell()
-    .storeAddress(Address.parse(owner))
-    .storeUint(nfts.length, 8);
-  for (const nft of nfts) {
-    toSign.storeAddress(Address.parse(nft));
-  }
-  const message = toSign.endCell().toBoc();
-  const hash = sha256_sync(message);
-  const signature = sign(hash, Buffer.from(secretKey, 'hex'));
-  console.log(signature.toString('hex'));
+  console.log('All NFTs valid');
 }
 
 main();


### PR DESCRIPTION
## Summary
- drop service public key and signature checks from jet contract
- adjust client and deploy script to match signatureless workflow
- update helper verification script, env template, and docs