### PR TITLE
Fix blueprint script exports

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,10 +1,18 @@
 import { compileFunc } from '@ton-community/func-js';
 import { readFileSync } from 'fs';
-import { Address, beginCell, contractAddress, internal, toNano, TonClient, WalletContractV4 } from 'ton';
+import {
+  Address,
+  beginCell,
+  contractAddress,
+  internal,
+  toNano,
+  TonClient,
+  WalletContractV4,
+} from 'ton';
 import { Cell } from 'ton-core';
 import { mnemonicToWalletKey } from 'ton-crypto';
 
-async function main() {
+export async function run() {
   const seed = process.env.SEED;
   const collection = process.env.COLLECTION_ADDRESS;
   const reward5 = process.env.REWARD5 || '0';
@@ -65,4 +73,8 @@ async function main() {
   console.log(`Deploy request sent to ${address.toString()}`);
 }
 
-main();
+// Allow direct execution with `ts-node` while supporting blueprint's `run` command
+if (require.main === module) {
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  run();
+}

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -27,7 +27,7 @@ export async function verifyNfts(
   }
 }
 
-async function main() {
+export async function run() {
   const args = process.argv.slice(2);
   if (args.length < 2) {
     console.log('Usage: ts-node scripts/verify.ts <owner> <nft1> [nft2 ...]');
@@ -51,7 +51,8 @@ async function main() {
   console.log('All NFTs valid');
 }
 
-// Execute main only when run as a script
+// Execute run only when invoked directly, allowing blueprint to import the script
 if (typeof require !== 'undefined' && require.main === module) {
-  main();
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  run();
 }


### PR DESCRIPTION
## Summary
- export `run` functions from deploy and verify scripts
- allow direct execution via ts-node while supporting `blueprint run`