### PR TITLE
fix: correct type-only imports

### DIFF
--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -1,4 +1,5 @@
-import { Address, Cell, beginCell, contractAddress, toNano, Contract, ContractProvider, Sender } from 'ton-core';
+import { Address, Cell, beginCell, contractAddress, toNano } from 'ton-core';
+import type { Contract, ContractProvider, Sender } from 'ton-core';
 import { TonClient, WalletContractV4, internal } from 'ton';
 
 export const OP_REDEEM = 0x72656465; // "redeem" prefix

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,8 @@ import { TonConnectButton, useTonAddress } from '@tonconnect/ui-react';
 import TonWeb from 'tonweb';
 import { TonClient } from 'ton';
 import { Address } from 'ton-core';
-import { JetConfig, readState } from '../../client/JetClient';
+import { readState } from '../../client/JetClient';
+import type { JetConfig } from '../../client/JetClient';
 
 const tonweb = new TonWeb(new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC'));
 const contract = Address.parse('EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true
-  }
+  },
+  "exclude": ["frontend"]
 }


### PR DESCRIPTION
## Summary
- use type-only imports for ton-core and JetClient types to avoid runtime errors
- exclude frontend sources from root TypeScript config

## Testing
- `npm --prefix frontend run build`
- `npm test`