### PR TITLE
feat: move frontend config to env

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Frontend configuration
+VITE_SWAP_CONTRACT="EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"
+# Address of NFT collection allowed to redeem
+VITE_NFT_CONTRACT=""

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,17 @@
 
 React + TypeScript + Vite setup used for the NFT to TON swapper demo.
 
+## Configuration
+
+Copy `.env.example` to `.env` and fill in the contract addresses:
+
+```bash
+cp .env.example .env
+```
+
+Set `VITE_SWAP_CONTRACT` to the Jet contract address and `VITE_NFT_CONTRACT` to
+the NFT collection address.
+
 ## Development
 
 ```bash

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,2 +1,2 @@
-export const SWAP_CONTRACT = 'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c';
+export const SWAP_CONTRACT = import.meta.env.VITE_SWAP_CONTRACT ?? '';
 export const NFT_CONTRACT = import.meta.env.VITE_NFT_CONTRACT ?? '';


### PR DESCRIPTION
## Summary
- read contract addresses from environment variables
- document env-based configuration for frontend
- add `.env.example` with required variables

## Testing
- `npm run lint --prefix frontend`
- `npm test`