### PR TITLE
fix: use Buffer when parsing contract state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { TonConnectButton, useTonAddress } from '@tonconnect/ui-react';
 import TonWeb from 'tonweb';
 import { Address, Cell } from 'ton-core';
+import { Buffer } from 'buffer';
 import { SWAP_CONTRACT } from './config';
 import './App.css';
 
@@ -35,7 +36,8 @@ export default function App() {
       if (!data) {
         throw new Error('No state found');
       }
-      const cell = Cell.fromBoc(TonWeb.utils.base64ToBytes(data))[0];
+      const boc = Buffer.from(TonWeb.utils.base64ToBytes(data));
+      const cell = Cell.fromBoc(boc)[0];
       const cs = cell.beginParse();
       setConfig({
         collection: cs.loadAddress(),


### PR DESCRIPTION
## Summary
- use `Buffer.from` to wrap state data before parsing

## Testing
- `npm test`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`