### PR TITLE
Add swap UI and handle missing contract

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -22,6 +22,21 @@
   margin-top: 1rem;
 }
 
+.swap-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.swap-form input {
+  padding: 0.5rem;
+  border: 1px solid #374151;
+  border-radius: 4px;
+  background: #111827;
+  color: #fff;
+}
+
 .error {
   margin-top: 1rem;
   color: #f87171;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { TonConnectButton, useTonAddress } from '@tonconnect/ui-react';
+import { TonConnectButton, useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import TonWeb from 'tonweb';
 import { Address, Cell } from 'ton-core';
 import { Buffer } from 'buffer';
@@ -7,7 +7,6 @@ import { SWAP_CONTRACT } from './config';
 import './App.css';
 
 const tonweb = new TonWeb(new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC'));
-const contract = Address.parse(SWAP_CONTRACT);
 
 type JetConfig = {
   collection: Address;
@@ -18,9 +17,12 @@ type JetConfig = {
 
 export default function App() {
   const walletAddress = useTonAddress();
+  const [tonConnectUI] = useTonConnectUI();
   const [balance, setBalance] = useState<string>('');
   const [config, setConfig] = useState<JetConfig | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [amount, setAmount] = useState('');
+  const [nftAddress, setNftAddress] = useState('');
 
   useEffect(() => {
     if (walletAddress) {
@@ -31,6 +33,15 @@ export default function App() {
   const loadState = async () => {
     try {
       setError(null);
+      if (!SWAP_CONTRACT) {
+        throw new Error('SWAP_CONTRACT is not defined');
+      }
+      let contract: Address;
+      try {
+        contract = Address.parse(SWAP_CONTRACT);
+      } catch {
+        throw new Error('Invalid swap contract address');
+      }
       const info = await tonweb.provider.getAddressInfo(contract.toString());
       const data = info.state?.data;
       if (!data) {
@@ -50,6 +61,33 @@ export default function App() {
     }
   };
 
+  const swap = async () => {
+    try {
+      setError(null);
+      if (!walletAddress) {
+        throw new Error('Connect wallet first');
+      }
+      if (!SWAP_CONTRACT) {
+        throw new Error('SWAP_CONTRACT is not defined');
+      }
+      if (!nftAddress) {
+        throw new Error('NFT address is required');
+      }
+      try {
+        Address.parse(nftAddress);
+      } catch {
+        throw new Error('Invalid NFT address');
+      }
+      const amountNano = TonWeb.utils.toNano(amount || '0');
+      await tonConnectUI.sendTransaction({
+        validUntil: Math.floor(Date.now() / 1000) + 60,
+        messages: [{ address: SWAP_CONTRACT, amount: amountNano.toString() }],
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
   return (
     <div className="app-container">
       <h1>NFT ↔ TON Swapper</h1>
@@ -59,6 +97,19 @@ export default function App() {
           Connected: {walletAddress} (balance: {balance})
         </p>
       )}
+      <div className="swap-form">
+        <input
+          placeholder="NFT address"
+          value={nftAddress}
+          onChange={(e) => setNftAddress(e.target.value)}
+        />
+        <input
+          placeholder="TON amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <button className="action" onClick={swap}>Swap</button>
+      </div>
       <button className="action" onClick={loadState}>Load contract state</button>
       {error && <p className="error">{error}</p>}
       {config && <pre className="config">{JSON.stringify(config, null, 2)}</pre>}


### PR DESCRIPTION
## Summary
- handle missing swap contract address to avoid blank screen
- add basic NFT↔TON swap form with TonConnect transaction
- style swap controls

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `npm test`