### PR TITLE
fix: ensure Buffer global before app load

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,8 +6,6 @@ import { Buffer } from 'buffer';
 import { SWAP_CONTRACT } from './config';
 import './App.css';
 
-if (!window.Buffer) window.Buffer = Buffer;
-
 const tonweb = new TonWeb(new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC'));
 
 type JetConfig = {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,5 @@
+import { Buffer } from 'buffer';
+
+if (!(globalThis as any).Buffer) {
+  (globalThis as any).Buffer = Buffer;
+}


### PR DESCRIPTION
## Summary
- add early Buffer polyfill for browser runtime
- reference polyfill before other modules to avoid `Buffer is not defined` errors

## Testing
- `npm test`
- `npm --prefix frontend run build`