### PR TITLE
feat: add responsive NFT swap frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,7 @@
 VITE_SWAP_CONTRACT="EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"
 # Address of NFT collection allowed to redeem
 VITE_NFT_CONTRACT=""
+# TON center JSON-RPC endpoint
+VITE_TONCENTER_URL="https://toncenter.com/api/v2/jsonRPC"
+# Base URL of TON API used to fetch NFTs
+VITE_TON_API_URL="https://tonapi.io/v2"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -11,7 +11,8 @@ cp .env.example .env
 ```
 
 Set `VITE_SWAP_CONTRACT` to the Jet contract address and `VITE_NFT_CONTRACT` to
-the NFT collection address.
+the NFT collection address. You can also override the TonCenter endpoint with
+`VITE_TONCENTER_URL` and the NFT lookup API with `VITE_TON_API_URL`.
 
 ## Development
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,6 +2,7 @@
   max-width: 600px;
   margin: 2rem auto;
   padding: 1.5rem;
+  width: 100%;
   background: #1f2937;
   border-radius: 8px;
   text-align: center;
@@ -35,6 +36,7 @@
   border-radius: 4px;
   background: #111827;
   color: #fff;
+  flex: 1;
 }
 
 .error {
@@ -49,5 +51,32 @@
   padding: 1rem;
   border-radius: 4px;
   overflow-x: auto;
+}
+
+.nft-info {
+  margin-top: 1rem;
+}
+
+@media (max-width: 480px) {
+  .app-container {
+    margin: 1rem;
+    padding: 1rem;
+  }
+
+  .app-container h1 {
+    font-size: 1.5rem;
+  }
+}
+
+@media (min-width: 640px) {
+  .swap-form {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .swap-form input {
+    max-width: 200px;
+  }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,18 @@
 import { useState, useEffect } from 'react';
 import { TonConnectButton, useTonAddress, useTonConnectUI } from '@tonconnect/ui-react';
 import TonWeb from 'tonweb';
-import { Address, Cell } from 'ton-core';
+import { Address, beginCell, Cell } from 'ton-core';
 import { Buffer } from 'buffer';
-import { SWAP_CONTRACT } from './config';
+import {
+  SWAP_CONTRACT,
+  NFT_CONTRACT,
+  TONCENTER_URL,
+  TON_API_URL,
+} from './config';
 import './App.css';
 
-const tonweb = new TonWeb(new TonWeb.HttpProvider('https://toncenter.com/api/v2/jsonRPC'));
+const tonweb = new TonWeb(new TonWeb.HttpProvider(TONCENTER_URL));
+const OP_REDEEM = 0x72656465;
 
 type JetConfig = {
   collection: Address;
@@ -21,13 +27,30 @@ export default function App() {
   const [balance, setBalance] = useState<string>('');
   const [config, setConfig] = useState<JetConfig | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [amount, setAmount] = useState('');
-  const [nftAddress, setNftAddress] = useState('');
+  const [nfts, setNfts] = useState<string[]>([]);
+  const [count, setCount] = useState('1');
 
   useEffect(() => {
     if (walletAddress) {
       tonweb.provider.getBalance(walletAddress).then((b) => setBalance(b.toString()));
     }
+  }, [walletAddress]);
+
+  useEffect(() => {
+    const fetchNfts = async () => {
+      if (!walletAddress || !NFT_CONTRACT) return;
+      try {
+        const res = await fetch(
+          `${TON_API_URL}/accounts/${walletAddress}/nfts?collection=${NFT_CONTRACT}`,
+        );
+        const data = await res.json();
+        const items = (data.nft_items as { address: string }[] | undefined) ?? [];
+        setNfts(items.map((i) => i.address));
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchNfts();
   }, [walletAddress]);
 
   const loadState = async () => {
@@ -70,18 +93,28 @@ export default function App() {
       if (!SWAP_CONTRACT) {
         throw new Error('SWAP_CONTRACT is not defined');
       }
-      if (!nftAddress) {
-        throw new Error('NFT address is required');
+      const cnt = parseInt(count);
+      if (isNaN(cnt) || cnt <= 0) {
+        throw new Error('Select amount of NFTs');
       }
-      try {
-        Address.parse(nftAddress);
-      } catch {
-        throw new Error('Invalid NFT address');
+      if (cnt > nfts.length) {
+        throw new Error('Not enough NFTs');
       }
-      const amountNano = TonWeb.utils.toNano(amount || '0');
+      const bodyBuilder = beginCell().storeUint(OP_REDEEM, 32).storeUint(cnt, 8);
+      nfts.slice(0, cnt).forEach((addr) =>
+        bodyBuilder.storeAddress(Address.parse(addr)),
+      );
+      const payload = bodyBuilder.endCell().toBoc().toString('base64');
+
       await tonConnectUI.sendTransaction({
         validUntil: Math.floor(Date.now() / 1000) + 60,
-        messages: [{ address: SWAP_CONTRACT, amount: amountNano.toString() }],
+        messages: [
+          {
+            address: SWAP_CONTRACT,
+            amount: TonWeb.utils.toNano('0.05').toString(),
+            payload,
+          },
+        ],
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -93,26 +126,32 @@ export default function App() {
       <h1>NFT ↔ TON Swapper</h1>
       <TonConnectButton />
       {walletAddress && (
-        <p className="status">
-          Connected: {walletAddress} (balance: {balance})
-        </p>
+        <>
+          <p className="status">
+            Connected: {walletAddress} (balance: {balance})
+          </p>
+          <div className="nft-info">You have {nfts.length} NFTs available.</div>
+          <div className="swap-form">
+            <input
+              type="number"
+              min="1"
+              max={nfts.length}
+              value={count}
+              onChange={(e) => setCount(e.target.value)}
+              disabled={nfts.length === 0}
+            />
+            <button className="action" onClick={swap} disabled={nfts.length === 0}>
+              Swap
+            </button>
+          </div>
+        </>
       )}
-      <div className="swap-form">
-        <input
-          placeholder="NFT address"
-          value={nftAddress}
-          onChange={(e) => setNftAddress(e.target.value)}
-        />
-        <input
-          placeholder="TON amount"
-          value={amount}
-          onChange={(e) => setAmount(e.target.value)}
-        />
-        <button className="action" onClick={swap}>Swap</button>
-      </div>
-      <button className="action" onClick={loadState}>Load contract state</button>
+      <button className="action" onClick={loadState}>
+        Load contract state
+      </button>
       {error && <p className="error">{error}</p>}
       {config && <pre className="config">{JSON.stringify(config, null, 2)}</pre>}
     </div>
   );
 }
+

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,2 +1,6 @@
 export const SWAP_CONTRACT = import.meta.env.VITE_SWAP_CONTRACT ?? '';
 export const NFT_CONTRACT = import.meta.env.VITE_NFT_CONTRACT ?? '';
+export const TONCENTER_URL =
+  import.meta.env.VITE_TONCENTER_URL ?? 'https://toncenter.com/api/v2/jsonRPC';
+export const TON_API_URL =
+  import.meta.env.VITE_TON_API_URL ?? 'https://tonapi.io/v2';

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Buffer } from 'buffer';
 
 if (!(globalThis as any).Buffer) {


### PR DESCRIPTION
## Summary
- make swap frontend responsive and env driven
- fetch wallet NFTs and let user choose how many to redeem
- document environment variables for TON endpoints

## Testing
- `npm test`
- `npm --prefix frontend run lint`