### PR TITLE
Fix TonConnect manifest and responsive layout

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,4 @@ VITE_NFT_CONTRACT=""
 VITE_TONCENTER_URL="https://toncenter.com/api/v2/jsonRPC"
 # Base URL of TON API used to fetch NFTs
 VITE_TON_API_URL="https://tonapi.io/v2"
+VITE_SITE_DOMAIN="nft2ton.onrender.com"

--- a/frontend/public/tonconnect-manifest.json
+++ b/frontend/public/tonconnect-manifest.json
@@ -1,5 +1,5 @@
 {
-  "url": "http://localhost",
+  "url": "https://nft2ton.onrender.com",
   "name": "NFT2TON Swapper",
   "iconUrl": "https://ton.org/img/logo.png"
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,13 +1,16 @@
 .app-container {
-  max-width: 600px;
-  margin: 2rem auto;
-  padding: 1.5rem;
   width: 100%;
-  background: #1f2937;
-  border-radius: 8px;
+  max-width: 600px;
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: #fff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .app-container h1 {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,6 +84,10 @@ export default function App() {
     }
   };
 
+  useEffect(() => {
+    loadState();
+  }, []);
+
   const swap = async () => {
     try {
       setError(null);
@@ -146,9 +150,6 @@ export default function App() {
           </div>
         </>
       )}
-      <button className="action" onClick={loadState}>
-        Load contract state
-      </button>
       {error && <p className="error">{error}</p>}
       {config && <pre className="config">{JSON.stringify(config, null, 2)}</pre>}
     </div>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -4,3 +4,5 @@ export const TONCENTER_URL =
   import.meta.env.VITE_TONCENTER_URL ?? 'https://toncenter.com/api/v2/jsonRPC';
 export const TON_API_URL =
   import.meta.env.VITE_TON_API_URL ?? 'https://tonapi.io/v2';
+export const SITE_DOMAIN =
+  import.meta.env.VITE_SITE_DOMAIN ?? 'nft2ton.onrender.com';

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,28 @@
+@import url('https://fonts.googleapis.com/css2?family=Epilogue:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
 }
 
 body {
   margin: 0;
   display: flex;
-  place-items: center;
+  align-items: center;
+  justify-content: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  background: #3a0766;
+  background: linear-gradient(
+      180deg,
+      #1a0064,
+      #3f0e65 6.77%,
+      #1a022d 15.62%,
+      #0a0028 39.58%,
+      #080220 64.58%,
+      #350759 91.67%
+    )
+    fixed;
+  color: #fff;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,10 +4,13 @@ import { createRoot } from 'react-dom/client';
 import { TonConnectUIProvider } from '@tonconnect/ui-react';
 import './index.css';
 import App from './App.tsx';
+import { SITE_DOMAIN } from './config';
+
+const manifestUrl = `https://${SITE_DOMAIN}/tonconnect-manifest.json`;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <TonConnectUIProvider manifestUrl="/tonconnect-manifest.json">
+    <TonConnectUIProvider manifestUrl={manifestUrl}>
       <App />
     </TonConnectUIProvider>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- configure domain via `VITE_SITE_DOMAIN` and use it for TonConnect manifest
- load swap contract state automatically and streamline UI
- restyle app with full-screen responsive layout

## Testing
- `npm test`
- `npm --prefix frontend run lint`