### PR TITLE
Avoid overflow when serializing NFT swap batches

### DIFF
--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -1,4 +1,4 @@
-import { Address, Cell, Dictionary, beginCell, contractAddress, toNano } from 'ton-core';
+import { Address, Cell, beginCell, contractAddress, toNano } from 'ton-core';
 import type { Contract, ContractProvider, Sender } from 'ton-core';
 import { TonClient, WalletContractV4, internal } from 'ton';
 
@@ -12,6 +12,18 @@ export type JetConfig = {
   reward10: bigint;
   reward20: bigint;
 };
+
+function serializeNftAddresses(nfts: Address[]): Cell {
+  const build = (index: number): Cell => {
+    const b = beginCell().storeAddress(nfts[index]);
+    console.log(`serialize cell ${index}: bits=${b.bits} refs=${b.refs}`);
+    if (index + 1 < nfts.length) {
+      b.storeRef(build(index + 1));
+    }
+    return b.endCell();
+  };
+  return build(0);
+}
 
 export function jetConfigToCell(config: JetConfig): Cell {
   return beginCell()
@@ -49,13 +61,15 @@ export class JetClient implements Contract {
   }
 
   async sendRedeem(provider: ContractProvider, via: Sender, opts: { nfts: Address[]; value?: bigint }) {
+    if (opts.nfts.length > 20) {
+      throw new Error('Up to 20 NFTs allowed in one swap');
+    }
     const value = opts.value ?? toNano('0.05');
-    const dict = Dictionary.empty(Dictionary.Keys.Uint(8), Dictionary.Values.Address());
-    opts.nfts.forEach((nft, i) => dict.set(i, nft));
+    const nftsCell = serializeNftAddresses(opts.nfts);
     const body = beginCell()
       .storeUint(OP_REDEEM, 32)
       .storeUint(opts.nfts.length, 8)
-      .storeDict(dict)
+      .storeRef(nftsCell)
       .endCell();
     await provider.internal(via, {
       value,
@@ -147,12 +161,14 @@ export async function redeem(
 ): Promise<void> {
   const walletContract = client.open(wallet);
   const seqno = await walletContract.getSeqno();
-  const dict = Dictionary.empty(Dictionary.Keys.Uint(8), Dictionary.Values.Address());
-  nfts.forEach((nft, i) => dict.set(i, nft));
+  if (nfts.length > 20) {
+    throw new Error('Up to 20 NFTs allowed in one swap');
+  }
+  const nftCell = serializeNftAddresses(nfts);
   const body = beginCell()
     .storeUint(OP_REDEEM, 32)
     .storeUint(nfts.length, 8)
-    .storeDict(dict)
+    .storeRef(nftCell)
     .endCell();
   await walletContract.sendTransfer({
     secretKey,

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -76,17 +76,17 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
 ;; Process redeem request
 () redeem(slice sender, slice cs) impure {
     int count = cs~load_uint(8);           ;; number of NFTs supplied
-    cell dict_in = cs~load_dict();         ;; dictionary of NFTs keyed by index
+    cell root = cs~load_ref();             ;; root cell with NFT addresses
+    accept_message();
 
     cell nft_dict = new_dict();           ;; track NFTs to prevent duplicates
     int valid = 1;
     int i = 0;
     int existed = 0;
-    int key = 0; slice data = null(); int unused = 0;
+    slice cur = root.begin_parse();
 
-    while (~(dict_empty?(dict_in))) {
-        (dict_in, (key, data, unused)) = ~udict::delete_get_min(dict_in, 8);
-        slice nft = data~load_msg_addr();
+    while (i < count) {
+        slice nft = cur~load_msg_addr();
         int h = slice_hash(nft);
         builder val = begin_cell().store_slice(nft);
         (nft_dict, existed) = udict_add_builder?(nft_dict, 256, h, val);
@@ -94,6 +94,19 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
             valid = 0;
         }
         i += 1;
+        if (i < count) {
+            if (slice_refs(cur) == 0) {
+                valid = 0;
+                i = count;
+            } else {
+                cell next = cur~load_ref();
+                cur = next.begin_parse();
+            }
+        } else {
+            if (slice_refs(cur) > 0) {
+                valid = 0;
+            }
+        }
     }
 
     ;; Ensure correct count and allowed batch sizes

--- a/tests/redeem.test.ts
+++ b/tests/redeem.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { Blockchain } from '@ton-community/sandbox';
+import { Cell, Address, toNano } from 'ton-core';
+import { compileFunc } from '@ton-community/func-js';
+import { readFileSync } from 'fs';
+import { JetClient } from '../client/JetClient';
+
+async function compileJet(): Promise<Cell> {
+  const result = await compileFunc({
+    targets: ['jet.fc'],
+    sources: {
+      'jet.fc':
+        readFileSync('contracts/stdlib.fc', 'utf8') +
+        '\n' +
+        readFileSync('contracts/jet.fc', 'utf8'),
+    },
+  });
+  if (result.status !== 'ok') {
+    throw new Error(result.message);
+  }
+  return Cell.fromBoc(Buffer.from(result.codeBoc, 'base64'))[0];
+}
+
+test('redeem 20 NFTs', async () => {
+  const blockchain = await Blockchain.create();
+  const admin = await blockchain.treasury('admin');
+  const user = await blockchain.treasury('user');
+  const code = await compileJet();
+  const jet = blockchain.openContract(
+    JetClient.createFromConfig(
+      {
+        admin: admin.address,
+        collection: admin.address,
+        reward5: toNano('5'),
+        reward10: toNano('10'),
+        reward20: toNano('20'),
+      },
+      code,
+    ),
+  );
+  await jet.sendDeploy(admin.getSender(), toNano('25'));
+
+  const nfts: Address[] = [];
+  for (let i = 0; i < 20; i++) {
+    const t = await blockchain.treasury('nft' + i);
+    nfts.push(t.address);
+  }
+
+  const res = await jet.sendRedeem(user.getSender(), { nfts, value: toNano('0.05') });
+  assert(res.transactions.some((t) => t.outMessages.size > 0));
+});
+


### PR DESCRIPTION
## Summary
- serialize NFT addresses into a chain of cells with `.storeRef`, logging bits/refs as the chain is built
- cap swap batches to 20 NFTs and parse the chained structure in the contract
- cover batch redemption in tests