### PR TITLE
refactor: centralize op codes

### DIFF
--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -1,9 +1,7 @@
 import { Address, Cell, beginCell, contractAddress, toNano } from 'ton-core';
 import type { Contract, ContractProvider, Sender } from 'ton-core';
 import { TonClient, WalletContractV4, internal } from 'ton';
-
-export const OP_REDEEM = 0x72656465; // "rede" prefix
-export const OP_WITHDRAW = 0x77697468; // "with" prefix
+import { OP_REDEEM, OP_WITHDRAW } from '../opcodes';
 
 export type JetConfig = {
   admin: Address;

--- a/frontend/src/components/SwapperLanding.tsx
+++ b/frontend/src/components/SwapperLanding.tsx
@@ -3,7 +3,7 @@ import { TonConnectButton, useTonAddress, useTonConnectUI } from '@tonconnect/ui
 import TonWeb from 'tonweb';
 import { Address, beginCell, Cell } from 'ton-core';
 import { SWAP_CONTRACT, NFT_CONTRACT, TON_API_URL } from '../config';
-const OP_REDEEM = 0x72656465;
+import { OP_REDEEM } from '../../../opcodes';
 
 const SWAP_OPTIONS = [
   { nfts: 5, reward: '0.3' },

--- a/opcodes.ts
+++ b/opcodes.ts
@@ -1,0 +1,2 @@
+export const OP_REDEEM = 0x72656465; // "rede" prefix
+export const OP_WITHDRAW = 0x77697468; // "with" prefix


### PR DESCRIPTION
## Summary
- centralize op codes for contract calls
- import shared op codes in Jet client and front-end

## Testing
- `npm test`