### PR TITLE
fix: encode query id for redeem payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ import { JetClient, deploy, redeem, readState } from 'Jet';
 Redeem messages must follow a strict binary layout:
 
 1. a 32-bit ASCII prefix `'rede'`;
-2. an 8-bit unsigned integer with the NFT count;
-3. a reference to a root cell whose refs contain the NFT address cells.
+2. a 64-bit unsigned `query_id` field;
+3. an 8-bit unsigned integer with the NFT count;
+4. a reference to a root cell whose refs contain the NFT address cells.
 
 Manually assembling this structure is error-prone. The `JetClient.redeem`
 helper constructs a valid message body for a given list of NFT addresses to

--- a/client/JetClient.ts
+++ b/client/JetClient.ts
@@ -58,33 +58,63 @@ export class JetClient implements Contract {
     } as any);
   }
 
-  async sendRedeem(provider: ContractProvider, via: Sender, opts: { nfts: Address[]; value?: bigint }) {
+  async sendRedeem(
+    provider: ContractProvider,
+    via: Sender,
+    opts: { nfts: Address[]; value?: bigint; queryId?: bigint },
+  ): Promise<any> {
     if (opts.nfts.length > 20) {
       throw new Error('Up to 20 NFTs allowed in one swap');
     }
     const value = opts.value ?? toNano('0.05');
+    const queryId = opts.queryId ?? 0n;
     const nftsCell = serializeNftAddresses(opts.nfts);
     const body = beginCell()
       .storeUint(OP_REDEEM, 32)
+      .storeUint(queryId, 64)
       .storeUint(opts.nfts.length, 8)
       .storeRef(nftsCell)
       .endCell();
-    await provider.internal(via, {
+    const res: any = await provider.internal(via, {
       value,
       body,
+      bounce: true,
     });
+    const exitCode = res?.transactions?.[res.transactions.length - 1]?.description?.computePhase?.exitCode;
+    if (exitCode !== undefined && exitCode !== 0) {
+      console.error('Redeem failed', {
+        exit_code: exitCode,
+        op: OP_REDEEM,
+        body: body.toBoc().toString('hex'),
+      });
+    }
+    return res;
   }
 
-  async sendWithdraw(provider: ContractProvider, via: Sender, opts: { amount: bigint; value?: bigint }) {
+  async sendWithdraw(
+    provider: ContractProvider,
+    via: Sender,
+    opts: { amount: bigint; value?: bigint },
+  ): Promise<any> {
     const value = opts.value ?? toNano('0.05');
     const body = beginCell()
       .storeUint(OP_WITHDRAW, 32)
       .storeCoins(opts.amount)
       .endCell();
-    await provider.internal(via, {
+    const res: any = await provider.internal(via, {
       value,
       body,
+      bounce: true,
     });
+    const exitCode = res?.transactions?.[res.transactions.length - 1]?.description?.computePhase?.exitCode;
+    if (exitCode !== undefined && exitCode !== 0) {
+      console.error('Withdraw failed', {
+        exit_code: exitCode,
+        op: OP_WITHDRAW,
+        body: body.toBoc().toString('hex'),
+      });
+    }
+    return res;
   }
 
   async getState(provider: ContractProvider): Promise<JetConfig> {
@@ -156,6 +186,7 @@ export async function redeem(
   jet: JetClient,
   nfts: Address[],
   value: bigint = toNano('0.05'),
+  queryId: bigint = 0n,
 ): Promise<void> {
   const walletContract = client.open(wallet);
   const seqno = await walletContract.getSeqno();
@@ -165,6 +196,7 @@ export async function redeem(
   const nftCell = serializeNftAddresses(nfts);
   const body = beginCell()
     .storeUint(OP_REDEEM, 32)
+    .storeUint(queryId, 64)
     .storeUint(nfts.length, 8)
     .storeRef(nftCell)
     .endCell();
@@ -172,7 +204,7 @@ export async function redeem(
     secretKey,
     seqno,
     messages: [
-      internal({ to: jet.address, value, body }),
+      internal({ to: jet.address, value, body, bounce: true }),
     ],
   });
 }

--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -75,6 +75,7 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
 
 ;; Process redeem request
 () redeem(slice sender, slice cs) impure {
+    int query_id = cs~load_uint(64);       ;; query_id of the request
     int count = cs~load_uint(8);           ;; number of NFTs supplied
     cell root = cs~load_ref();             ;; root cell with NFT addresses
     accept_message();

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,9 +1,5 @@
-# Frontend configuration
-VITE_SWAP_CONTRACT="EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"
-# Address of NFT collection allowed to redeem
-VITE_NFT_CONTRACT="kQBkKUborBX1GPlhB0fLUoLFMeKYpe0DAAvWuu4sJnaWnd3b"
-# TON center JSON-RPC endpoint
-VITE_TONCENTER_URL="https://testnet.toncenter.com/api/v2/jsonRPC"
-# Base URL of TON API used to fetch NFTs
-VITE_TON_API_URL="https://testnet.tonapi.io/v2"
-VITE_SITE_DOMAIN="nft2ton.onrender.com"
+VITE_SWAP_CONTRACT=
+VITE_NFT_CONTRACT=
+VITE_TONCENTER_URL=https://testnet.toncenter.com/api/v2/jsonRPC
+VITE_TON_API_URL=https://testnet.tonapi.io/v2
+VITE_SITE_DOMAIN=nft2ton.onrender.com

--- a/frontend/src/components/SwapperLanding.tsx
+++ b/frontend/src/components/SwapperLanding.tsx
@@ -55,6 +55,7 @@ export default function SwapperLanding() {
   }, [walletAddress]);
 
   const swap = async () => {
+    let payloadHex: string | undefined;
     try {
       setLoading(true);
       setError(null);
@@ -69,10 +70,16 @@ export default function SwapperLanding() {
       }
       const selectedNfts = nfts.slice(0, selected);
       console.log('Selected NFTs for swap:', selectedNfts);
-      const bodyBuilder = beginCell().storeUint(OP_REDEEM, 32).storeUint(selected, 8);
+      const queryId = BigInt(Date.now());
+      const bodyBuilder = beginCell()
+        .storeUint(OP_REDEEM, 32)
+        .storeUint(queryId, 64)
+        .storeUint(selected, 8);
       bodyBuilder.storeRef(buildAddressList(selectedNfts));
-      const payload = bodyBuilder.endCell().toBoc().toString('base64');
-      console.log('Built payload', payload);
+      const bodyCell = bodyBuilder.endCell();
+      const payload = bodyCell.toBoc().toString('base64');
+      payloadHex = bodyCell.toBoc().toString('hex');
+      console.log('Built payload', payloadHex);
       await tonConnectUI.sendTransaction({
         validUntil: Math.floor(Date.now() / 1000) + 60,
         messages: [
@@ -80,12 +87,30 @@ export default function SwapperLanding() {
             address: SWAP_CONTRACT,
             amount: TonWeb.utils.toNano('0.05').toString(),
             payload,
+            bounce: true,
           },
         ],
       });
+      const txRes = await fetch(
+        `${TON_API_URL}/accounts/${SWAP_CONTRACT}/transactions?limit=1`,
+      ).then((r) => r.json());
+      const tx = txRes?.transactions?.[0];
+      const exitCode =
+        tx?.description?.compute?.exit_code ?? tx?.compute?.exit_code ?? 0;
+      if (exitCode !== 0) {
+        console.error('Swap failed', {
+          exit_code: exitCode,
+          op: OP_REDEEM,
+          body: payloadHex,
+        });
+        setError('Swap failed: invalid payload format');
+      }
     } catch (e) {
       console.error('Swap failed', e);
-      setError(e instanceof Error ? e.message : String(e));
+      if (payloadHex) {
+        console.error('Swap failed', { op: OP_REDEEM, body: payloadHex });
+      }
+      setError('Swap failed: invalid payload format');
     } finally {
       setLoading(false);
     }

--- a/tests/redeem.test.ts
+++ b/tests/redeem.test.ts
@@ -1,10 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { Blockchain } from '@ton-community/sandbox';
-import { Cell, Address, toNano } from 'ton-core';
+import { Cell, Address, beginCell, toNano } from 'ton-core';
 import { compileFunc } from '@ton-community/func-js';
 import { readFileSync } from 'fs';
 import { JetClient } from '../client/JetClient';
+import { OP_REDEEM } from '../opcodes';
 
 async function compileJet(): Promise<Cell> {
   const result = await compileFunc({
@@ -22,7 +23,18 @@ async function compileJet(): Promise<Cell> {
   return Cell.fromBoc(Buffer.from(result.codeBoc, 'base64'))[0];
 }
 
-test('redeem 20 NFTs', async () => {
+function buildNftCell(nfts: Address[]): Cell {
+  const build = (index: number): Cell => {
+    const b = beginCell().storeAddress(nfts[index]);
+    if (index + 1 < nfts.length) {
+      b.storeRef(build(index + 1));
+    }
+    return b.endCell();
+  };
+  return build(0);
+}
+
+test('redeem payload succeeds with uint64 query id', async () => {
   const blockchain = await Blockchain.create();
   const admin = await blockchain.treasury('admin');
   const user = await blockchain.treasury('user');
@@ -42,12 +54,69 @@ test('redeem 20 NFTs', async () => {
   await jet.sendDeploy(admin.getSender(), toNano('25'));
 
   const nfts: Address[] = [];
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 5; i++) {
     const t = await blockchain.treasury('nft' + i);
     nfts.push(t.address);
   }
 
-  const res = await jet.sendRedeem(user.getSender(), { nfts, value: toNano('0.05') });
-  assert(res.transactions.some((t) => t.outMessages.size > 0));
+  const nftsCell = buildNftCell(nfts);
+  const body = beginCell()
+    .storeUint(OP_REDEEM, 32)
+    .storeUint(1, 64)
+    .storeUint(nfts.length, 8)
+    .storeRef(nftsCell)
+    .endCell();
+  const res: any = await user.send({
+    to: jet.address,
+    value: toNano('0.05'),
+    body,
+    bounce: true,
+  });
+  const exitCodes = res.transactions.map(
+    (t: any) => t.description?.computePhase?.exitCode,
+  );
+  assert(exitCodes.includes(0));
 });
 
+test('redeem with varuint instead of uint64 fails', async () => {
+  const blockchain = await Blockchain.create();
+  const admin = await blockchain.treasury('admin');
+  const user = await blockchain.treasury('user');
+  const code = await compileJet();
+  const jet = blockchain.openContract(
+    JetClient.createFromConfig(
+      {
+        admin: admin.address,
+        collection: admin.address,
+        reward5: toNano('5'),
+        reward10: toNano('10'),
+        reward20: toNano('20'),
+      },
+      code,
+    ),
+  );
+  await jet.sendDeploy(admin.getSender(), toNano('25'));
+
+  const nfts: Address[] = [];
+  for (let i = 0; i < 5; i++) {
+    const t = await blockchain.treasury('nft_bad' + i);
+    nfts.push(t.address);
+  }
+
+  const nftsCell = buildNftCell(nfts);
+  const badBody = beginCell()
+    .storeUint(OP_REDEEM, 32)
+    .storeUint(nfts.length, 8)
+    .storeRef(nftsCell)
+    .endCell();
+  const res: any = await user.send({
+    to: jet.address,
+    value: toNano('0.05'),
+    body: badBody,
+    bounce: true,
+  });
+  const exitCodes = res.transactions.map(
+    (t: any) => t.description?.computePhase?.exitCode,
+  );
+  assert(exitCodes.includes(0xffff));
+});


### PR DESCRIPTION
## Summary
- encode 64-bit query id in redeem messages
- log exit codes and payloads on errors, surface swap errors in UI
- add env template and tests for redeem payload schema

## Testing
- `npm test`