### PR TITLE
fix: remove unsupported bounce flag

### DIFF
--- a/frontend/src/components/SwapperLanding.tsx
+++ b/frontend/src/components/SwapperLanding.tsx
@@ -87,7 +87,6 @@ export default function SwapperLanding() {
             address: SWAP_CONTRACT,
             amount: TonWeb.utils.toNano('0.05').toString(),
             payload,
-            bounce: true,
           },
         ],
       });


### PR DESCRIPTION
## Summary
- remove unsupported `bounce` field from TON connect transaction request to satisfy TypeScript types

## Testing
- `npm run build`
- `npm test`
