### PR TITLE
Handle malformed redeem payload gracefully

### DIFF
--- a/contracts/jet.fc
+++ b/contracts/jet.fc
@@ -75,8 +75,17 @@ global int   ctx_reward20;     ;; reward for 20 NFTs
 
 ;; Process redeem request
 () redeem(slice sender, slice cs) impure {
+    ;; Ensure payload has enough bits for query_id and count
+    if (slice_bits(cs) < 72) {
+        return ();                        ;; malformed message
+    }
     int query_id = cs~load_uint(64);       ;; query_id of the request
     int count = cs~load_uint(8);           ;; number of NFTs supplied
+
+    ;; Root cell with NFT addresses must be provided
+    if (slice_refs(cs) == 0) {
+        return ();
+    }
     cell root = cs~load_ref();             ;; root cell with NFT addresses
     accept_message();
 

--- a/tests/redeem.test.ts
+++ b/tests/redeem.test.ts
@@ -78,7 +78,7 @@ test('redeem payload succeeds with uint64 query id', async () => {
   assert(exitCodes.includes(0));
 });
 
-test('redeem with varuint instead of uint64 fails', async () => {
+test('redeem with varuint instead of uint64 is ignored', async () => {
   const blockchain = await Blockchain.create();
   const admin = await blockchain.treasury('admin');
   const user = await blockchain.treasury('user');
@@ -118,5 +118,6 @@ test('redeem with varuint instead of uint64 fails', async () => {
   const exitCodes = res.transactions.map(
     (t: any) => t.description?.computePhase?.exitCode,
   );
-  assert(exitCodes.includes(0xffff));
+  // Malformed payload should be ignored without aborting the transaction
+  assert(exitCodes.includes(0));
 });


### PR DESCRIPTION
## Summary
- prevent crashes when redeem payload lacks query id/count or NFT list
- test that malformed redeem message is ignored rather than aborted

## Testing
- `npm test`